### PR TITLE
Ansible check mode testing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,65 @@
+name: check
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: bool
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set git repo and branch environment variables
+        shell: bash
+        run: |-
+          echo "[info] git repo: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+          echo "GIT_REPO=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" >> $GITHUB_ENV
+
+          if [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "[info] git branch: $GITHUB_REF_NAME"
+            echo "BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          fi
+
+      - name: Set test UDFs
+        shell: bash
+        run: ./scripts/test-vars.sh
+
+      - name: Update runner ssh configs
+        shell: bash
+        run: |-
+          # update ssh for localhost connections via ansible 
+          declare -A ssh_dict
+          ssh_dict["#ListenAddress 0.0.0.0"]="ListenAddress 0.0.0.0"
+          ssh_dict["PermitRootLogin yes"]="PermitRootLogin no"
+          ssh_dict["#PermitRootLogin no"]="PermitRootLogin no"
+          ssh_dict["#PubkeyAuthentication yes"]="PubkeyAuthentication yes"
+          ssh_dict["#PasswordAuthentication no"]="PasswordAuthentication no"
+          ssh_dict["PasswordAuthentication yes"]="PasswordAuthentication no"
+          ssh_dict["#PasswordAuthentication yes"]="PasswordAuthentication no"
+
+          for conf in "${!ssh_dict[@]}"; do
+            sudo sed -i -e "s/${conf}/${ssh_dict[$conf]}/g" /etc/ssh/sshd_config
+          done
+          sudo systemctl restart ssh
+
+      - name: Run deploy script in check mode
+        shell: bash
+        run: sudo -E ./scripts/kafka-deploy.sh
+        env:
+          TOKEN_PASSWORD: 9ff48ad7
+          CHECK_MODE: 1
+
+      - name: Setup tmate session for debugging
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ !cancelled() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,10 +26,14 @@ jobs:
           echo "[info] git repo: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
           echo "GIT_REPO=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" >> $GITHUB_ENV
 
-          if [ "$GITHUB_REF_NAME" != "main" ]; then
-            echo "[info] git branch: $GITHUB_REF_NAME"
-            echo "BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+            BRANCH="$GITHUB_BASE_REF"
+          elif [ "$GITHUB_REF_NAME" != "main" ]; then
+            BRANCH="$GITHUB_REF_NAME"
           fi
+
+          echo "[info] git branch: $GITHUB_REF_NAME"$GITHUB_REF_NAME
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 
       - name: Set test UDFs
         shell: bash

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
             BRANCH="$GITHUB_REF_NAME"
           fi
 
-          echo "[info] git branch: $GITHUB_REF_NAME"$GITHUB_REF_NAME
+          echo "[info] git branch: $BRANCH"
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 
       - name: Set test UDFs

--- a/provision.yml
+++ b/provision.yml
@@ -40,6 +40,7 @@
         ca_password: "{{ lookup('password', '/dev/null length=25 chars=ascii_letters,digits') }}"
         sudo_password: {{ lookup('password', '/dev/null length=25 chars=ascii_letters,digits') }}
     no_log: true
+    tags: test
 
   - name: creating kafka servers
     linode.cloud.instance:
@@ -79,6 +80,7 @@
                 ip_pub1: {{ info.results[count].instance.ipv4[0] }}
                 ip_priv1: {{ info.results[count].instance.ipv4[1] }}
             {%- endfor %}
+    tags: test
 
   - name: add kafka nodes to inventory
     blockinfile:
@@ -91,6 +93,7 @@
         {%- for count in range(cluster_size - 1) %}
         {{ info.results[count + 1].instance.ipv4[0] }} {% if count < controller_count - 1 %}role='controller and broker'{%else%}role='broker only'{%endif%}
         {%- endfor %}
+    tags: test
 
   - name: wait for port 22 to become open
     wait_for:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -30,6 +30,7 @@
     - ufw
     - acl
     state: latest
+  tags: test
 
 - name: fail2ban jail.local
   copy:

--- a/roles/common/tasks/ufw_rules.yml
+++ b/roles/common/tasks/ufw_rules.yml
@@ -26,5 +26,5 @@
 - name: Enable ufw
   community.general.ufw:
     state: enabled
-  async: 60
+  async: "{{ ansible_check_mode | ternary(0,60) }}"
   poll: 0

--- a/roles/kafka/tasks/configure.yml
+++ b/roles/kafka/tasks/configure.yml
@@ -59,7 +59,7 @@
 
 - name: format data directory for controller and broker nodes
   command:
-    cmd: "{{ kafka_bin_directory }}/kafka-storage.sh format -t {{ cluster_uuid.stdout }} -c {{ kafka_config_directory }}/config/kraft/server.properties"
+    cmd: "{{ kafka_bin_directory }}/kafka-storage.sh format -t {{ cluster_uuid.stdout }} -c {{ kafka_config_directory }}/config/kraft/server.properties --ignore-formatted"
   become: true
   become_user: kafka
   run_once: true

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -3,15 +3,20 @@
 
 - name: configure hostname
   import_tasks: hostname.yml
+  tags: test
 
 - name: create kafka user
   import_tasks: user.yml
+  tags: test
 
 - name: installing kafka
   import_tasks: install.yml
+  tags: test
 
 - name: configure cluster certs
   import_tasks: ssl.yml
+  tags: test
 
 - name: configure kafka
   import_tasks: configure.yml
+  tags: test

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -15,15 +15,20 @@ function controller_sshkey {
     chmod 600 ${SSH_KEY_PATH}
     eval $(ssh-agent)
     ssh-add ${SSH_KEY_PATH}
+    test:check
 }
+
 # build instance vars before cluster deployment
 function build {
-  local KAFKA_VERSION="${KAFKA_VERSION}"
   local LINODE_PARAMS=($(curl -sH "Authorization: Bearer ${TOKEN_PASSWORD}" "https://api.linode.com/v4/linode/instances/${LINODE_ID}" | jq -r .label,.type,.region,.image))
   local LINODE_TAGS=$(curl -sH "Authorization: Bearer ${TOKEN_PASSWORD}" "https://api.linode.com/v4/linode/instances/${LINODE_ID}" | jq -r .tags)
+  local KAFKA_VERSION="${KAFKA_VERSION}"
   local group_vars="${WORK_DIR}/group_vars/kafka/vars"
   local TEMP_ROOT_PASS=$(openssl rand -base64 32)
-controller_sshkey
+
+  test:check
+  controller_sshkey
+
   cat << EOF >> ${group_vars}
 # user vars
 sudo_username: ${SUDO_USERNAME}
@@ -59,9 +64,9 @@ function deploy {
 }
 
 ## cleanup ##
-
 function cleanup {
   if [ "$?" != "0" ]; then
+    echo "Error: $BASH_COMMAND failed with exit code $?"
     if [ -n "$GITHUB_ENV" ]; then
       echo "PLAYBOOK_FAILED=1" | tee -a $GITHUB_ENV
     fi
@@ -77,8 +82,65 @@ function destroy {
   ansible-playbook destroy.yml
 }
 
+# test functions
+function test:check {
+  if [ $"${CHECK_MODE}" == "1" ]; then
+    # get name of caller (parent) function
+    local name="${FUNCNAME[0]}"
+    local caller="${FUNCNAME[1]}"
+    local user=$(whoami)
+    echo "[info] $name $caller"
+
+    if [ "${caller}" == "controller_sshkey" ]; then
+      [ "${user}" == 'root' ] && HOME_DIR="/root" || HOME_DIR="${HOME}"
+      echo $ANSIBLE_SSH_PUB_KEY >> ${HOME_DIR}/.ssh/authorized_keys
+    fi
+
+    if [ "${caller}" == "build" ]; then
+      export LINODE_PARAMS=("${INSTANCE_PREFIX}" "g6-standard-8" "us-ord" "linode/ubuntu22.04")
+      export LINODE_TAGS="test"
+    fi
+  fi
+}
+
+function test:instance_info {
+  echo "[info] ${FUNCNAME[0]}"
+  # for provision.yml in check mode
+  echo -e "info:\n  results:" > info.yml
+  count=100
+
+  for host in $(seq $CLUSTER_SIZE); do
+    echo -e '    - {"instance": {"ipv4": ["127.1.0.'$count'", "127.2.0.'$count'"]}}' >> info.yml
+    ((count++))
+  done
+}
+
+function test:provision {
+  test:instance_info
+  echo "[info] ${FUNCNAME[0]}"
+  ansible-playbook -v -i hosts provision.yml --check --extra-vars "@info.yml"
+}
+
+function test:site {
+  echo "[info] ${FUNCNAME[0]}"
+  # run just a couple tagged tasks to write dependent vars and files...  
+  ansible-playbook -v -i hosts provision.yml --tags test --extra-vars "@info.yml"
+  ansible-playbook -v -i hosts site.yml --become --tags test --forks 1 # --forks 1: prevent race condition from parallel processes writing the same file 
+  # then run site.yml in check mode
+  ansible-playbook -vv -i hosts site.yml --become --check
+
+}
+
+function test {
+  echo "[info] running ansible playbooks in check mode"
+  build
+  test:provision
+  test:site
+}
+
 # main
 case $1 in
     build) "$@"; exit;;
     deploy) "$@"; exit;;
+    test) "$@"; exit;;
 esac

--- a/scripts/test-vars.sh
+++ b/scripts/test-vars.sh
@@ -39,5 +39,4 @@ set_vars() {
 }
 
 # main
-build_dict
 set_vars

--- a/scripts/test-vars.sh
+++ b/scripts/test-vars.sh
@@ -8,6 +8,9 @@
 # environment, but that is not the case with local testing or CI environment.
 # You will also have to set this separately.
 
+# NOTE: For local testing, manually set the $BRANCH and $GIT_REPO environment
+# variables as needed.
+
 declare -A UDF_VARS
 UDF_VARS["KAFKA_VERSION"]="3.8.0"
 UDF_VARS["SUDO_USERNAME"]="admin"


### PR DESCRIPTION
Adding a new workflow for testing ansible playbooks in check mode. This is a "dry run" type check that doesn't write anything to the target hosts, but can validate modules that support check mode. This is a way to catch errors without testing against real infra. See [Check Mode (“Dry Run”)](https://docs.ansible.com/ansible/2.8/user_guide/playbooks_checkmode.html) and [Using check mode](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_checkmode.html#using-check-mode) for more info.

Some minor changes made to the playbooks themselves. I honestly hate that because tests should test code the way it is, however, these changes do not impact the normal execution of the playbooks. The changes are as follows:
-  Tagging some tasks with `test`, that we need to run before check mode runs. Since check mode doesn't write to the filesystem, it will dry run validate a task that writes, but then subsequent tasks that rely on that file existing will fail. An example of this is the `apt install` task which installs `fail2ban.` A subsequent task works with the `fail2ban` configuration file, but since check mode didn't write that file during the `apt` task, that file needs to exist before hand. Another example includes the Kafka SSL tasks, which reply on files (i.e. `ca private key`) generated from previous tasks. The simplest way to do this is to let ansible do the heavy lifting for us. We just tag a couple tasks that write those files, run it normally, and then we can run the entire playbook in check mode with success.
- `async` will always fail in check mode, so a conditional is needed to set the value to `0` **only when running in check mode**.
- The `--ignore-formatted` flag was appended to the `kafka-storage.sh` command. This is needed because we are simulating execution of tasks on multiple hosts, when in reality it's just one actual host. This means that running `kafka-storage.sh` on the next "fake host" will attempt try to format the same, previously formatted storage target. This flag just tells the script to move on if the target if already formatted, and then continue formatting any others. More on the `--ignore-formatted` flag [here](https://cwiki.apache.org/confluence/display/KAFKA/KIP-785%3A+Automatic+storage+formatting).

The other changes include creation of `test-vars.sh` for populating environment variables that would otherwise be set by UDFs from the stackscript (`kafka-deploy.sh`) and several testing functions added to the `run.sh` script that does most of the heavy lifting outside of ansible itself. This PR also adds additional debug print statements, and refactoring to improve readability and ease both local testing and CI testing. The later is accomplished by introducing `if` statements in place of having to uncomment code just for testing.